### PR TITLE
RemoveEntity

### DIFF
--- a/scripts/pg/entity.js
+++ b/scripts/pg/entity.js
@@ -8,12 +8,14 @@ define(function () {
 	
 	entity.create = function (map, tile, type) {
 		var entity = new this.typeMap[type]();
-			entity.init(map, tile);
+			entity.map = map;
+			entity.tile = tile;
+			entity.init();
 		return entity;
 	};
 
 	entity.prototype = {	
-		draw : function(tile) {
+		draw : function() {
 			
 		},
 		

--- a/scripts/pg/entity/amplifier.js
+++ b/scripts/pg/entity/amplifier.js
@@ -9,11 +9,32 @@ define(["pg/entity", "utils", "config", "dom", "pg/gs"], function (entity, utils
 	utils.extend(entity, amplifier);
 	
 	Object.assign(amplifier.prototype, {
-		init: function (map, tile) {
+		init: function () {
+			var search_tiles = this.map.get_tile_area(this.tile.x, this.tile.y, 1);
+			
+			for (var search_tile_index = 0; search_tile_index < search_tiles.length; search_tile_index++) {
+				var search_tile = search_tiles[search_tile_index];
+				
+				if (search_tile && search_tile.entity && search_tile.entity.name === 'square') {
+					search_tile.entity.project_power(search_tile.entity.power_range + 1);
+				}
+			}
 		},
 		
-		update : function (map, tile, step_time) {
-			var gather_tiles = map.get_tile_area(tile.x, tile.y, this.gather_range),
+		destroy: function() {
+			var search_tiles = this.map.get_tile_area(this.tile.x, this.tile.y, 1);
+			
+			for (var search_tile_index = 0; search_tile_index < search_tiles.length; search_tile_index++) {
+				var search_tile = search_tiles[search_tile_index];
+				
+				if (search_tile && search_tile.entity && search_tile.entity.name === 'square') {
+					search_tile.entity.project_power(search_tile.entity.power_range - 1);
+				}
+			}
+		},
+		
+		update : function (step_time) {
+			var gather_tiles = this.map.get_tile_area(this.tile.x, this.tile.y, this.gather_range),
 				gather = 0;
 			
 			for (var gather_tile_index = 0; gather_tile_index < gather_tiles.length; gather_tile_index++) {
@@ -27,9 +48,9 @@ define(["pg/entity", "utils", "config", "dom", "pg/gs"], function (entity, utils
 			gs.pixels += ((gather / 1000) * step_time);
 		},
 		
-		draw : function(tile) {			
-			var startX = (config.border_size - config.pixel_size) + (config.pixel_size * tile.x);
-			var startY = (config.border_size - config.pixel_size) + (config.pixel_size * tile.y);
+		draw : function() {			
+			var startX = (config.border_size - config.pixel_size) + (config.pixel_size * this.tile.x);
+			var startY = (config.border_size - config.pixel_size) + (config.pixel_size * this.tile.y);
 			var width = height = (config.pixel_size - (2 * config.border_size));		
 			
 			dom.ctx.fillStyle = "#225577";

--- a/scripts/pg/entity/square.js
+++ b/scripts/pg/entity/square.js
@@ -10,12 +10,12 @@ define(["pg/entity", "utils", "config", "dom", "pg/gs"], function (entity, utils
 	utils.extend(entity, square);
 	
 	Object.assign(square.prototype, {
-		init: function (map, tile) {
-			this.project_power(map, tile, 2);
+		init: function () {
+			this.project_power(2);
 		},
 		
-		update : function (map, tile, step_time) {
-			var gather_tiles = map.get_tile_area(tile.x, tile.y, this.gather_range),
+		update : function (step_time) {
+			var gather_tiles = this.map.get_tile_area(this.tile.x, this.tile.y, this.gather_range),
 				gather = 0;
 			
 			for (var gather_tile_index = 0; gather_tile_index < gather_tiles.length; gather_tile_index++) {
@@ -29,9 +29,9 @@ define(["pg/entity", "utils", "config", "dom", "pg/gs"], function (entity, utils
 			gs.pixels += ((gather / 1000) * step_time);
 		},
 		
-		project_power : function (map, tile, range) {
-			var current_range = map.get_tile_area(tile.x, tile.y, this.power_range),
-				new_range     = map.get_tile_area(tile.x, tile.y, range);
+		project_power : function (range) {
+			var current_range = this.map.get_tile_area(this.tile.x, this.tile.y, this.power_range),
+				new_range     = this.map.get_tile_area(this.tile.x, this.tile.y, range);
 				
 			if (range == this.power_range) {
 				return;
@@ -41,7 +41,7 @@ define(["pg/entity", "utils", "config", "dom", "pg/gs"], function (entity, utils
 				for (var new_tile_index = 0; new_tile_index < new_range.length; new_tile_index++) {
 					var new_tile = new_range[new_tile_index];
 					if (current_range.indexOf(new_tile) == -1) {
-						new_tile.register_source(tile);
+						new_tile.register_source(this.tile);
 					}
 				}
 			}
@@ -50,7 +50,7 @@ define(["pg/entity", "utils", "config", "dom", "pg/gs"], function (entity, utils
 				for (var old_tile_index = 0; old_tile_index < current_range.length; old_tile_index++) {
 					var old_tile = current_range[old_tile_index];
 					if (new_range.indexOf(old_tile) == -1) {
-						old_tile.remove_source(tile);
+						old_tile.remove_source(this.tile);
 					}
 				}
 			}
@@ -58,9 +58,9 @@ define(["pg/entity", "utils", "config", "dom", "pg/gs"], function (entity, utils
 			this.power_range = range;
 		},
 		
-		draw : function(tile) {			
-			var startX = (config.border_size - config.pixel_size) + (config.pixel_size * tile.x);
-			var startY = (config.border_size - config.pixel_size) + (config.pixel_size * tile.y);
+		draw : function() {			
+			var startX = (config.border_size - config.pixel_size) + (config.pixel_size * this.tile.x);
+			var startY = (config.border_size - config.pixel_size) + (config.pixel_size * this.tile.y);
 			var width = height = (config.pixel_size - (2 * config.border_size));		
 			
 			dom.ctx.fillStyle = "#227755";

--- a/scripts/pg/pixelmap.js
+++ b/scripts/pg/pixelmap.js
@@ -17,7 +17,6 @@ define(["dom", "config", "pg/pixeltile"], function(dom, config, pixeltile) {
 				this.map[i][j] = new pixeltile(i, j, this);
 			}	
 		}
-	
 				
 		this.zoom_level = config.default_play_size;
 		
@@ -80,6 +79,17 @@ define(["dom", "config", "pg/pixeltile"], function(dom, config, pixeltile) {
 				entity = tile.create_entity(type);
 				this.entity_map[x] = this.entity_map[x] || {};
 				this.entity_map[x][y] = tile;
+			}
+		},
+		
+		remove_entity_at : function (x, y) {
+			var tile = this.get_tile_at(x,y),
+			    entity;
+			
+			if (tile && tile.entity) {
+				tile.destroy_entity();
+				this.entity_map[x] = this.entity_map[x] || {};
+				delete this.entity_map[x][y];
 			}
 		},
 		

--- a/scripts/pg/pixeltile.js
+++ b/scripts/pg/pixeltile.js
@@ -30,7 +30,7 @@ define(["dom", "config", "pg/entity"], function (dom, config, entity) {
 		
 		update_entity: function (step_time){
 			if (this.entity != null) {
-				this.entity.update(this.map, this, step_time);
+				this.entity.update(step_time);
 			}		
 		},
 		
@@ -38,9 +38,14 @@ define(["dom", "config", "pg/entity"], function (dom, config, entity) {
 			return this.entity = entity.create(this.map, this, type);
 		},
 		
+		destroy_entity: function () {
+			this.entity.destroy();
+			delete this.entity;
+		},
+		
 		draw: function () {
 			if (this.entity){
-				this.entity.draw(this);
+				this.entity.draw();
 			} else {			
 				var startX = (config.border_size - config.pixel_size) + (config.pixel_size * this.x);
 				var startY = (config.border_size - config.pixel_size) + (config.pixel_size * this.y);


### PR DESCRIPTION
-Can now remove entity through map.remove_entity_at(x,y)
-This deregisters the entity from the map, so update() is no longer
called on it.
-The entity's destroy() method is called, then the tile removes it's
reference to the entity.
-Entity now stores references to both the map and the tile it's on